### PR TITLE
Fix: Backward selection with empty text nodes

### DIFF
--- a/packages/slate-react/src/utils/dom.ts
+++ b/packages/slate-react/src/utils/dom.ts
@@ -69,6 +69,13 @@ export const isPlainTextOnlyPaste = (event: ClipboardEvent) => {
 }
 
 /**
+ * Check if a DOM node is a TextNode without content.
+ */
+
+export const isEmptyTextNode = (node: DOMNode): Boolean =>
+  node.nodeType === 3 && /^\s$/.test(node.textContent!)
+
+/**
  * Normalize a DOM point so that it always refers to a text node.
  */
 


### PR DESCRIPTION
See https://github.com/ianstormtaylor/slate/pull/3574.